### PR TITLE
Dynamic emitting

### DIFF
--- a/public/services/messages.js
+++ b/public/services/messages.js
@@ -5,8 +5,9 @@ const socket = io('https://twine-rt.com', {
   transports: ['websocket', 'polling'],
 });
 
-socket.on('connect', () => {
-  console.log('Connected to the Twine server');
+socket.on('connect', async () => {
+  console.log('Connected to twine server');
+  await socket.emit('stateRecovery');
 });
 
 socket.on("message", (data) => {

--- a/public/services/messages.js
+++ b/public/services/messages.js
@@ -2,24 +2,63 @@ fetch('https://twine-rt.com/set-cookie', { credentials: 'include' })
 
 const socket = io('https://twine-rt.com', { 
   withCredentials: true,
-  transports: ['websocket', 'polling'],
+  transports: ['websocket'],
 });
+
+const messages = document.getElementById('messages');
 
 socket.on('connect', async () => {
   console.log('Connected to twine server');
   await socket.emit('stateRecovery');
 });
 
-socket.on("message", (data) => {
+const logMessageInfo = (data) => {
   console.log('data from client: ', data);
   console.log('room id from client: ', data.room);
   socket.emit("updateSessionTS", (data.timestamp));
-  const messages = document.getElementById('messages');
+}
+
+const addMessageToDOM = (data) => {
   const item = document.createElement('li');
   item.textContent = data.message;
   messages.appendChild(item);
   window.scrollTo(0, document.body.scrollHeight);
-});
+}
+
+const listenOn = (socket, roomName, callback) => {
+  console.log("roomName:", roomName);
+  socket.on("message", (payload) => {
+    console.log("payload:", payload);
+    if (payload.room === roomName) {
+      callback(payload);
+    }
+  });
+};
+
+// socket.on("message", (data) => {
+//   logMessageInfo(data);
+//   addMessageToDOM(data);
+// });
+
+listenOn(socket, "A", (payload) => {
+  logMessageInfo(payload);
+  addMessageToDOM(payload);
+})
+
+listenOn(socket, "B", (payload) => {
+  logMessageInfo(payload);
+  addMessageToDOM(payload);
+})
+
+listenOn(socket, "C", (payload) => {
+  logMessageInfo(payload);
+  addMessageToDOM(payload);
+})
+
+listenOn(socket, "D", (payload) => {
+  logMessageInfo(payload);
+  addMessageToDOM(payload);
+})
 
 socket.on('roomJoined', (msg) => {
   console.log(msg);


### PR DESCRIPTION
- Made a `logMessageInfo` function to contain the logging for each individual listener.
- Made an `addMessageToDOM` function to contain the functionality for creating a `li` element, add the message as its content, and adding the `li` element to the DOM.
- Made a `listenOn` function that wraps the `socket.on` listener and only executes a callback function if the websocket event name matches the name passed in as an argument. 
- Now, rooms `A`, B`, `C`, and `D` have separate listeners. 
- This functionality can be easily wrapped into our client library.