### PR TITLE
resolved cookie/socket issue

### DIFF
--- a/public/services/messages.js
+++ b/public/services/messages.js
@@ -64,11 +64,6 @@ socket.on('roomJoined', (msg) => {
   console.log(msg);
 });
 
-if (document.readyState === 'complete') {
-  // The document is still loading, we can add the event listener normally.
-  console.log('COMPLETE');
-} 
-
 const disconnectBtn = document.getElementById('disconnect');
 disconnectBtn.addEventListener('click', (e) => {
   e.preventDefault();

--- a/public/services/messages.js
+++ b/public/services/messages.js
@@ -1,4 +1,4 @@
-fetch('https://twine-rt.com/set-cookie', { credentials: 'include' })
+await fetch('https://twine-rt.com/set-cookie', { credentials: 'include' })
 
 const socket = io('https://twine-rt.com', { 
   withCredentials: true,
@@ -64,23 +64,27 @@ socket.on('roomJoined', (msg) => {
   console.log(msg);
 });
 
+if (document.readyState === 'complete') {
+  // The document is still loading, we can add the event listener normally.
+  console.log('COMPLETE');
+} 
+
 const disconnectBtn = document.getElementById('disconnect');
 disconnectBtn.addEventListener('click', (e) => {
   e.preventDefault();
   socket.disconnect();
   setTimeout(() => {
     socket.connect();
-  }, 10000)
+  }, 3000)
 });
 
 // fires event when a room is selected from the dropdown
-document.addEventListener('DOMContentLoaded', () => {
-  const options = document.getElementById('options');
+const options = document.getElementById('options');
 
-  options.addEventListener('change', () => {
-    const selectedOption = options.value;
-    // join room <button value> on change event
-    // server then emits back to roomJoined (below)
-    socket.emit('join', `${selectedOption}`);
-  });
+options.addEventListener('change', () => {
+  const selectedOption = options.value;
+  // join room <button value> on change event
+  // server then emits back to roomJoined (below)
+  socket.emit('join', `${selectedOption}`);
+  console.log('JOINED ROOM');
 });


### PR DESCRIPTION
- Added `await` to the `fetch` to ensure the Twine cookie is set before establishing the WS connection
- Removed the `DOMContentLoaded` line in `messages.js`: the `await` delays execution enough that the DOM loads before that line: in that case, the code nested in the `DOMContentLoaded` listener never executes and the client cannot join rooms